### PR TITLE
Some dependency improvements

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install various apt dependencies
-      run: sudo apt-get install libsqlite3-dev python3-pip libcrypto++-dev
+      run: sudo apt-get install libsqlite3-dev python3-pip
 
     - name: Install meson
       run: sudo pip3 install meson ninja

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install various apt dependencies
-      run: sudo apt-get install libsqlite3-dev nlohmann-json3-dev python3-pip libcrypto++-dev
+      run: sudo apt-get install libsqlite3-dev python3-pip libcrypto++-dev
 
     - name: Install meson
       run: sudo pip3 install meson ninja

--- a/README.md
+++ b/README.md
@@ -185,11 +185,10 @@ Note that if you run using the Docker-compose file, there is a 'command'
 statement there for --rnd-admin-password which you need to uncomment once.
 
 # Building (optional)
-Requires libsqlite3-dev nlohmann-json. On Debian derived
-systems the following works:
+Requires libsqlite3-dev. On Debian derived systems the following works:
 
 ```
-apt install libsqlite3-dev nlohmann-json3-dev python3-pip pkg-config
+apt install libsqlite3-dev python3-pip pkg-config
 ```
 In addition, the project requires a recent version of meson, which you can
 get with 'pip3 install meson ninja' or perhaps 'pip install

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,2 @@
+/*/
+!packagefiles/

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = nlohmann_json-3.11.2
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
+source_filename = nlohmann_json-3.11.2.zip
+source_hash = e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed
+wrapdb_version = 3.11.2-1
+
+[provide]
+nlohmann_json = nlohmann_json_dep


### PR DESCRIPTION
* Added a fallback wrap for `nlohmann_json`
* Added a `subprojects/.gitignore` to keep `git status` output tidy.
* The `libcrypto++-dev` CI build dependency isn't needed anymore since it was removed in 3557399178b2469fba310ddeb178db201ae5fb33.